### PR TITLE
Module was using it's own mongoose version which is causing it to do …

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,10 +17,8 @@
   },
   "author": "Oliver Brooks",
   "license": "MIT",
-  "dependencies": {
-    "mongoose": "~3.8.8"
-  },
   "devDependencies": {
+    "mongoose": "~3.8.8",
     "bluebird": "^2.3.6",
     "mocha": "~1.18.2",
     "chai": "~1.9.1"


### PR DESCRIPTION
…the wrong fetch since it doesn't have DB access to the project's proper mongoose instance.  Updated package.json to remove mongoose ~3.8.8 as a dependency and make it a devDependency instead to fix this issue.
